### PR TITLE
Remmoved Write access check for ffmpeg binary

### DIFF
--- a/MediaToolkit src/MediaToolkit/Util/Document.cs
+++ b/MediaToolkit src/MediaToolkit/Util/Document.cs
@@ -40,7 +40,7 @@ namespace MediaToolkit.Util
 
             try
             {
-                fileStream = file.Open(FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
             }
             catch (IOException)
             {


### PR DESCRIPTION
Hi, I got problems on Mono when setting path in constructor to Engine. Changed FileAccess to read for binary ffmpeg.