### PR TITLE
Remove redundant parameter when generating thumbnail

### DIFF
--- a/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
+++ b/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
@@ -127,6 +127,7 @@ namespace MediaToolkit.Test
                 };
                 engine.GetThumbnail(inputFile, outputFile, options);
             }
+            Assert.IsTrue(File.Exists(outputPath));
         }
 
         [TestCase]

--- a/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
+++ b/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
@@ -110,6 +110,10 @@ namespace MediaToolkit.Test
         public void Can_GetThumbnail()
         {
             string outputPath = string.Format(@"{0}\Get_Thumbnail_Test.jpg", Path.GetDirectoryName(_outputFilePath));
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
 
             var inputFile = new MediaFile { Filename = _inputFilePath };
             var outputFile = new MediaFile { Filename = outputPath };

--- a/MediaToolkit src/MediaToolkit/CommandBuilder.cs
+++ b/MediaToolkit src/MediaToolkit/CommandBuilder.cs
@@ -37,7 +37,6 @@ namespace MediaToolkit
                 conversionOptions.Seek.GetValueOrDefault(TimeSpan.FromSeconds(1)).TotalSeconds);
 
             commandBuilder.AppendFormat(" -i \"{0}\" ", inputFile.Filename);
-            commandBuilder.AppendFormat(" -t {0} ", 1);
             commandBuilder.AppendFormat(" -vframes {0} ", 1);
 
             return commandBuilder.AppendFormat(" \"{0}\" ", outputFile.Filename).ToString();


### PR DESCRIPTION
The [FFmpeg documentation](http://ffmpeg.org/ffmpeg.html) makes it sound like `-vframes` and `-t` are mutually exclusive:

> If you want to extract just a limited number of frames, you can use the above command in combination with the -vframes or -t option, or in combination with -ss to start extracting from a certain point in time.

...and I had one video where no output file was produced (and no error reported) when both `-vframes` and `-t` were specified.