### PR TITLE
Path to ffmpeg can be specified in constructor.

### DIFF
--- a/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
+++ b/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
@@ -113,8 +113,10 @@ namespace MediaToolkit.Test
 
             var inputFile = new MediaFile { Filename = _inputFilePath };
             var outputFile = new MediaFile { Filename = outputPath };
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var localMediaToolkitFfMpeg = Path.Combine(localAppData, "MediaToolkit", "ffmpeg.exe");
 
-            using (var engine = new Engine())
+            using (var engine = new Engine(localMediaToolkitFfMpeg))
             {
                 engine.ConvertProgressEvent += engine_ConvertProgressEvent;
                 engine.ConversionCompleteEvent += engine_ConversionCompleteEvent;

--- a/MediaToolkit src/MediaToolkit/Engine.cs
+++ b/MediaToolkit src/MediaToolkit/Engine.cs
@@ -20,6 +20,16 @@
         /// </summary>
         public event EventHandler<ConversionCompleteEventArgs> ConversionCompleteEvent;
 
+        public Engine()
+        {
+            
+        }
+
+        public Engine(string ffMpegPath) : base(ffMpegPath)
+        {
+            
+        }
+
         /// -------------------------------------------------------------------------------------------------
         /// <summary>
         ///     <para> ---</para>


### PR DESCRIPTION
This makes it possible to not need a configuration file.

Alternatively, the `DefaultFFmpegFilePath` could be similarly initialized to a folder the current user is guaranteed access, as some user accounts may not have permission to create folders at the root of the current drive.