### PR TITLE
Fixing custom command and added ability fro custom path via constructor

### DIFF
--- a/MediaToolkit src/MediaToolkit/Engine.cs
+++ b/MediaToolkit src/MediaToolkit/Engine.cs
@@ -16,6 +16,23 @@
     public class Engine : EngineBase
     {
         /// <summary>
+        /// Standard constructor, 
+        /// If an AppSettings "mediaToolkit.ffmpeg.path" is declared, this path will be used for FFMpeg, otherwise this library will extract one from itself.
+        /// </summary>
+        public Engine() : base()
+        {
+        }
+
+        /// <summary>
+        /// Uses FFMpeg from the specified location
+        /// </summary>
+        public Engine(string ffMpegPath)
+            : base()
+        {
+          
+        }
+
+        /// <summary>
         ///     Event queue for all listeners interested in conversionComplete events.
         /// </summary>
         public event EventHandler<ConversionCompleteEventArgs> ConversionCompleteEvent;

--- a/MediaToolkit src/MediaToolkit/Engine.cs
+++ b/MediaToolkit src/MediaToolkit/Engine.cs
@@ -230,23 +230,25 @@
 #endif
                     try
                     {
+                        
                         receivedMessagesLog.Insert(0, received.Data);
-
-                        RegexEngine.TestVideo(received.Data, engineParameters);
-                        RegexEngine.TestAudio(received.Data, engineParameters);
-
-                        Match matchDuration = RegexEngine.Index[RegexEngine.Find.Duration].Match(received.Data);
-                        if (matchDuration.Success)
+                        if (engineParameters.InputFile != null)
                         {
-                            if (engineParameters.InputFile.Metadata == null)
+                            RegexEngine.TestVideo(received.Data, engineParameters);
+                            RegexEngine.TestAudio(received.Data, engineParameters);
+                        
+                            Match matchDuration = RegexEngine.Index[RegexEngine.Find.Duration].Match(received.Data);
+                            if (matchDuration.Success)
                             {
-                                engineParameters.InputFile.Metadata = new Metadata();
+                                if (engineParameters.InputFile.Metadata == null)
+                                {
+                                    engineParameters.InputFile.Metadata = new Metadata();
+                                }
+
+                                TimeSpan.TryParse(matchDuration.Groups[1].Value, out totalMediaDuration);
+                                engineParameters.InputFile.Metadata.Duration = totalMediaDuration;
                             }
-
-                            TimeSpan.TryParse(matchDuration.Groups[1].Value, out totalMediaDuration);
-                            engineParameters.InputFile.Metadata.Duration = totalMediaDuration;
                         }
-
                         ConversionCompleteEventArgs convertCompleteEvent;
                         ConvertProgressEventArgs progressEvent;
 

--- a/MediaToolkit src/MediaToolkit/EngineBase.cs
+++ b/MediaToolkit src/MediaToolkit/EngineBase.cs
@@ -57,10 +57,6 @@
             this.EnsureFFmpegIsNotUsed ();
         }
 
-
-
-
-
         private void EnsureFFmpegIsNotUsed()
         {
             if (!Document.IsLocked(this.FFmpegFilePath)) return;


### PR DESCRIPTION
I fixed using customCommands as it was always assuming InputFile to be available, which it isnt when using customcommands.

For the constructors, https://github.com/olivierdagenais/MediaToolkit/commit/916569cdba1a241c98dfaa4ef966e09ceba875b6 is probably a better commit.