### PR TITLE
Use invariant culture for formatting Double values in command line

### DIFF
--- a/MediaToolkit src/MediaToolkit/CommandBuilder.cs
+++ b/MediaToolkit src/MediaToolkit/CommandBuilder.cs
@@ -2,6 +2,7 @@
 using MediaToolkit.Options;
 using MediaToolkit.Util;
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace MediaToolkit
@@ -33,7 +34,7 @@ namespace MediaToolkit
         {
             var commandBuilder = new StringBuilder();
 
-            commandBuilder.AppendFormat(" -ss {0} ",
+            commandBuilder.AppendFormat(CultureInfo.InvariantCulture, " -ss {0} ",
                 conversionOptions.Seek.GetValueOrDefault(TimeSpan.FromSeconds(1)).TotalSeconds);
 
             commandBuilder.AppendFormat(" -i \"{0}\" ", inputFile.Filename);
@@ -52,7 +53,7 @@ namespace MediaToolkit
 
             // Media seek position
             if (conversionOptions.Seek != null)
-                commandBuilder.AppendFormat(" -ss {0} ", conversionOptions.Seek.Value.TotalSeconds);
+                commandBuilder.AppendFormat(CultureInfo.InvariantCulture, " -ss {0} ", conversionOptions.Seek.Value.TotalSeconds);
 
             commandBuilder.AppendFormat(" -i \"{0}\" ", inputFile.Filename);
 


### PR DESCRIPTION
On systems where the decimal separator is a , instead of . MediaToolkit
will not work correctly because it does not use invariant culture to
format Double values, generating command line arguments like "-ss 923,52"
which ffmpeg will reject with the error "Invalid duration specification
for ss: 923,52". Using the invariant culture to format the arguments fixes
this.

Signed-off-by: Axel Gembe <axel@gembe.net>