### PR TITLE
Made audio bit rate optional, because not provided by FFmpeg/FFprobe for WEBM videos

### DIFF
--- a/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
+++ b/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
@@ -180,7 +180,8 @@ namespace MediaToolkit.Test
             Debug.Assert(inputMeta.AudioData.SampleRate != null, "Sample rate not found", "   Likely due to Regex code");
             Debug.Assert(inputMeta.AudioData.ChannelOutput != null, "Channel output not found",
                 "Likely due to Regex code");
-            Debug.Assert(inputMeta.AudioData.BitRateKbs != 0, "Audio bitrate not found", " Likely due to Regex code");
+            // Audio bit rate for some reson isn't returned by FFmreg for WEBM videos.
+            //Debug.Assert(inputMeta.AudioData.BitRateKbs != 0, "Audio bitrate not found", " Likely due to Regex code");
 
             PrintMetadata(inputMeta);
         }

--- a/MediaToolkit src/MediaToolkit/Util/RegexEngine.cs
+++ b/MediaToolkit src/MediaToolkit/Util/RegexEngine.cs
@@ -153,7 +153,7 @@ namespace MediaToolkit.Util
                     Format = matchAudioFormatHzChannel[1].ToString(),
                     SampleRate = matchAudioFormatHzChannel[2].ToString(),
                     ChannelOutput = matchAudioFormatHzChannel[3].ToString(),
-                    BitRateKbs = Convert.ToInt32(matchAudioBitRate[1].ToString())
+                    BitRateKbs = !String.IsNullOrWhiteSpace(matchAudioBitRate[1].ToString()) ? Convert.ToInt32(matchAudioBitRate[1].ToString()) : 0
                 };
         }
 


### PR DESCRIPTION
Hi Aydin,

Great project and good effort. Thanks for this.

I tried using it for my project, but straight away hit an issue where MediaToolkit was throwing exceptions if I attempted to get metadata or convert WEBM videos. 
After a quick investigation, found that FFmpeg/FFprobe for some reason does not provide audio bit rate for WEBM files.
I then added a simple check for the string value not being empty and removed the check in the test to make it pass.
This will do for my needs, but you may want to put some more robust conversion code there, e.g. int.TryParse() or wrap Convert.ToInt32 with a try{}catch{} in case some non-number string gets in there - up to you.
This pull request is just to shed some light on the problem, feel free to resolve this issue in your own way.
Let me know if you need help or more info on this issue.

Kind regards.
Oleg.