### PR TITLE
Audio Bitrate options

### DIFF
--- a/MediaToolkit src/MediaToolkit/CommandBuilder.cs
+++ b/MediaToolkit src/MediaToolkit/CommandBuilder.cs
@@ -72,6 +72,10 @@ namespace MediaToolkit
                 return commandBuilder.ToString();
             }
 
+            // Audio bit rate
+            if (conversionOptions.AudioBitRate != null)
+                commandBuilder.AppendFormat(" -ab {0}k", conversionOptions.AudioBitRate);
+
             // Audio sample rate
             if (conversionOptions.AudioSampleRate != AudioSampleRate.Default)
                 commandBuilder.AppendFormat(" -ar {0} ", conversionOptions.AudioSampleRate.Remove("Hz"));

--- a/MediaToolkit src/MediaToolkit/Options/ConversionOptions.cs
+++ b/MediaToolkit src/MediaToolkit/Options/ConversionOptions.cs
@@ -30,6 +30,11 @@ namespace MediaToolkit.Options
         }
 
         /// <summary>
+        ///     Audio bit rate
+        /// </summary>
+        public int? AudioBitRate = null;
+
+        /// <summary>
         ///     Audio sample rate
         /// </summary>
         public AudioSampleRate AudioSampleRate = AudioSampleRate.Default;


### PR DESCRIPTION
Conversion option for audio bitrate added

There are two flags for bitrate conversion. One for video ( "-b"), and one for audio ("-ab"). This just adds support for audio bitrate conversion.