### PR TITLE
Get thumbnail as byte array from stdout

### DIFF
--- a/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
+++ b/MediaToolkit src/MediaToolkit.Test/ConvertTest.cs
@@ -140,6 +140,29 @@ namespace MediaToolkit.Test
         }
 
         [TestCase]
+        public void Can_GetThumbnailAsByteArray()
+        {
+            var inputFile = new MediaFile { Filename = _inputFilePath };
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var localMediaToolkitFfMpeg = Path.Combine(localAppData, "MediaToolkit", "ffmpeg.exe");
+
+            using (var engine = new Engine(localMediaToolkitFfMpeg))
+            {
+                engine.ConvertProgressEvent += engine_ConvertProgressEvent;
+                engine.ConversionCompleteEvent += engine_ConversionCompleteEvent;
+
+                engine.GetMetadata(inputFile);
+
+                var options = new ConversionOptions
+                {
+                    Seek = TimeSpan.FromSeconds(inputFile.Metadata.Duration.TotalSeconds / 2)
+                };
+                var thumbnailByteArray = engine.GetThumbnail(inputFile, options);
+                Assert.AreEqual(9530, thumbnailByteArray.Length);
+            }
+        }
+
+        [TestCase]
         public void Can_GetThumbnailFromHTTPLink()
         {
             string outputPath = string.Format(@"{0}\Get_Thumbnail_FromHTTP_Test.jpg", Path.GetDirectoryName(_outputFilePath));

--- a/MediaToolkit src/MediaToolkit/CommandBuilder.cs
+++ b/MediaToolkit src/MediaToolkit/CommandBuilder.cs
@@ -21,6 +21,8 @@ namespace MediaToolkit
 
                 case FFmpegTask.GetThumbnail:
                     return GetThumbnail(engineParameters.InputFile, engineParameters.OutputFile, engineParameters.ConversionOptions);
+                case FFmpegTask.GetThumbnailStream:
+                    return GetThumbnail(engineParameters.InputFile, engineParameters.ConversionOptions);
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -42,6 +44,19 @@ namespace MediaToolkit
 
             return commandBuilder.AppendFormat(" \"{0}\" ", outputFile.Filename).ToString();
         }
+
+        private static string GetThumbnail(MediaFile inputFile,  ConversionOptions conversionOptions)
+        {
+            var commandBuilder = new StringBuilder();
+
+            commandBuilder.AppendFormat(CultureInfo.InvariantCulture, " -ss {0} ", conversionOptions.Seek.GetValueOrDefault(TimeSpan.FromSeconds(1)).TotalSeconds);
+
+            commandBuilder.AppendFormat(" -i \"{0}\"", inputFile.Filename);
+            commandBuilder.AppendFormat(" -vframes {0}", 1);
+            commandBuilder.AppendFormat(" -f mjpeg pipe:1");
+            return commandBuilder.ToString();
+        }
+
 
         private static string Convert(MediaFile inputFile, MediaFile outputFile, ConversionOptions conversionOptions)
         {

--- a/MediaToolkit src/MediaToolkit/Engine.cs
+++ b/MediaToolkit src/MediaToolkit/Engine.cs
@@ -311,17 +311,10 @@
                 {
                     FileStream baseStream = this.FFmpegProcess.StandardOutput.BaseStream as FileStream;
                     this.thumbnailByteArray = null;
-                    int lastRead = 0;
 
                     using (MemoryStream ms = new MemoryStream())
                     {
-                        byte[] buffer = new byte[4096];
-                        do
-                        {
-                            lastRead = baseStream.Read(buffer, 0, buffer.Length);
-                            ms.Write(buffer, 0, lastRead);
-                        } while (lastRead > 0);
-
+                        baseStream.CopyTo(ms);
                         this.thumbnailByteArray = ms.ToArray();
                     }
                 }

--- a/MediaToolkit src/MediaToolkit/EngineParameters.cs
+++ b/MediaToolkit src/MediaToolkit/EngineParameters.cs
@@ -17,6 +17,10 @@ namespace MediaToolkit
         }
 
         /// -------------------------------------------------------------------------------------------------
+        /// <summary>   Indicates whether we will be returning from stdout. </summary>
+        /// <value> True if returning from stdout, false otherwise. </value>
+        internal bool ReturningStandardOutput { get; set; }
+        /// -------------------------------------------------------------------------------------------------
         /// <summary>   Gets or sets options for controlling the conversion. </summary>
         /// <value> Options that control the conversion. </value>
         internal ConversionOptions ConversionOptions { get; set; }

--- a/MediaToolkit src/MediaToolkit/FFmpegTask.cs
+++ b/MediaToolkit src/MediaToolkit/FFmpegTask.cs
@@ -11,6 +11,9 @@ namespace MediaToolkit
         GetMetaData,
 
         /// <summary>   An enum constant representing the get thumbnail option. </summary>
-        GetThumbnail
+        GetThumbnail,
+
+        /// <summary>   An enum constant representing the get thumbnail via a byte stream option. </summary>
+        GetThumbnailStream
     }
 }


### PR DESCRIPTION
I've added a method GetThumbnail that doesn't have an outputFile parameter but instead returns a byte array. This byte array is the result of the thumbnail being piped out from FFmpeg.