### PR TITLE
Updated README for typo in 'src' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,5 +180,5 @@ Samples
 Licensing
 ---------  
 - MediaToolkit is licensed under the [MIT license](https://github.com/AydinAdn/MediaToolkit/blob/master/LICENSE.md)
-- MediaToolkit uses [FFmpeg](http://ffmpeg.org), a multimedia framework which is licensed under the [LGPLv2.1 license](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html), its source can be downloaded from [here](https://github.com/AydinAdn/MediaToolkit/tree/master/FFMpeg%20src)
+- MediaToolkit uses [FFmpeg](http://ffmpeg.org), a multimedia framework which is licensed under the [LGPLv2.1 license](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html), its source can be downloaded from [here](https://github.com/AydinAdn/MediaToolkit/tree/master/FFmpeg%20src)
 


### PR DESCRIPTION
Changed the URL from ".../FFMpeg%20src" to ".../FFmpeg%20src" to fix
broken link.